### PR TITLE
Feature/pending on qos

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+Layout/LineLength:
+  Max: 80
+
+AllCops:
+  NewCops: enable

--- a/pending_on_qos.rb
+++ b/pending_on_qos.rb
@@ -20,25 +20,31 @@ class PendingOnQos
 
   def raid
     @partition_thresholds.each do |partition, threshold|
-      start_time = (Time.now - @partition_thresholds[:partition])
-                   .strftime('%Y-%m-:%d')
+      start_time = (Time.now - threshold).strftime('%Y-%m-%d')
 
       squeue_cmd = [
         'squeue',
         '--format="%A,%R,%V"',
         '--noheader',
-        '--parsable2',
         "--partition=#{partition}",
         '--state=PENDING'
       ].join(' ')
+      
+      output = `#{squeue_cmd}`.split('\n') 
+
+      puts output
     end
 
     @collector.report!(
-      name: 'pending_on_qos',
-      value: 255,
-      help: 'Number of jobs pending for QoS reasons',
-      type: 'gauge',
-      labels: { partition: 'nodes' }
+      'pending_on_qos',
+      255,
+      {
+        help: 'Number of jobs pending for QoS reasons',
+        type: 'gauge',
+        labels: {
+          partition: 'nodes'
+        }
+      }
     )
   end
 end

--- a/pending_on_qos.rb
+++ b/pending_on_qos.rb
@@ -24,7 +24,7 @@ class PendingOnQos
     @partition_thresholds.each do |partition, threshold|
       squeue_cmd = [
         'squeue',
-        '--format="%A,%R,%V"',
+        '--format="%R,%V"',
         '--noheader',
         "--partition=#{partition}",
         '--state=PENDING'
@@ -35,7 +35,7 @@ class PendingOnQos
       end
 
       count = data.count do |columns|
-        (Time.now.to_i - DateTime.parse(columns[2]).to_time.to_i) > threshold
+        (Time.now.to_i - DateTime.parse(columns[1]).to_time.to_i) > threshold
       end
 
       @collector.report!(

--- a/pending_on_qos.rb
+++ b/pending_on_qos.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# For each Viking partition, report the number of jobs pending due to QoS
+# reasons.
+class PendingOnQos
+  def initialize(collector, config)
+    @collector = collector
+    @partition_thresholds = {
+      nodes: 604_800,
+      week: 1_209_600,
+      month: 2_419_200,
+      himem: 604_800,
+      himem_week: 1_209_600,
+      gpu: 604_800,
+      interactive: 900,
+      test: 900,
+      preempt: 2_419_200
+    }
+  end
+
+  def raid
+    @partition_thresholds.each do |partition, threshold|
+      start_time = (Time.now - @partition_thresholds[:partition])
+                   .strftime('%Y-%m-:%d')
+
+      squeue_cmd = [
+        'squeue',
+        '--format="%A,%R,%V"',
+        '--noheader',
+        '--parsable2',
+        "--partition=#{partition}",
+        '--state=PENDING'
+      ].join(' ')
+    end
+
+    @collector.report!(
+      name: 'pending_on_qos',
+      value: 255,
+      help: 'Number of jobs pending for QoS reasons',
+      type: 'gauge',
+      labels: { partition: 'nodes' }
+    )
+  end
+end


### PR DESCRIPTION
Add a raider for gauging how many jobs are PENDING on each partition due to QoS reasons, for longer than a threshold number of seconds.

The raider:

* Gets a minimal amount of information from `squeue` about pending jobs
* Counts how many have "QOS" in their pending reason
* Reports the count per partition to the `Collector`